### PR TITLE
Switched emotions[key] reference to val

### DIFF
--- a/lib/threading.py
+++ b/lib/threading.py
@@ -64,4 +64,4 @@ def emote(thread_name, emotions):
     while True:
         for key, val in emotions.items():
             if (state == val.id):
-                emotions[key].play(frame_time)
+                val.play(frame_time)


### PR DESCRIPTION
Just did a quick fix to clean up the weird `emotions[key]` reference in emote when `val` is already what is needed.